### PR TITLE
✨ 学習ログサイト用にJekyll構成をセットアップ

### DIFF
--- a/habit-log/_config.yml
+++ b/habit-log/_config.yml
@@ -1,0 +1,4 @@
+title: "学習ログ"
+description: "毎日のGit/GitHub学習記録"
+theme: minima
+baseurl: "/daily-commit-log" # あなたのリポジトリ名

--- a/habit-log/_posts/2025-05-02-github-pages.md
+++ b/habit-log/_posts/2025-05-02-github-pages.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: "GitHub PagesとJekyllの理解"
+date: 2025-05-02
+---
+
+今日は GitHub Pages の基本と、Jekyll で学習ログを公開する仕組みを学びました！
+
+- `_config.yml` で設定できる
+- `_posts/` を使うとブログ風になる


### PR DESCRIPTION
habit-log 配下に GitHub Pages 用の Jekyll 構成ファイルを追加しました。
- `_config.yml` でサイト設定を記述
- `_posts/2025-05-02-github-pages.md` に初回ログを投稿